### PR TITLE
fix: allows full range of function characters

### DIFF
--- a/playground/src/impure.js
+++ b/playground/src/impure.js
@@ -3,8 +3,17 @@ function defineComponent (options) {
   return options
 }
 
+function $createConfig (options) {
+  console.log('this should be in final bundle')
+  return options
+}
+
 export const comp = defineComponent({
   someComponent: true
+})
+
+export const config = $createConfig({
+  someConfig: true
 })
 
 export const bar = 'world'

--- a/playground/src/pure.js
+++ b/playground/src/pure.js
@@ -3,8 +3,17 @@ function defineComponent (options) {
   return options
 }
 
+function $createConfig (options) {
+  console.log('this should not be in final bundle')
+  return options
+}
+
 export const comp = defineComponent({
   someComponent: true
+})
+
+export const config = $createConfig({
+  someConfig: true
 })
 
 export const foo = 'hello'

--- a/playground/vite.config.mjs
+++ b/playground/vite.config.mjs
@@ -4,7 +4,7 @@ import { PluginPure } from 'rollup-plugin-pure'
 export default defineConfig({
   plugins: [
     PluginPure({
-      functions: ['defineComponent'],
+      functions: ['defineComponent', '$createConfig'],
       include: [/(?<!im)pure\.js$/],
     }),
   ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,11 +13,15 @@ export interface PureAnnotationsOptions {
 
 export function PluginPure(options: PureAnnotationsOptions): Plugin {
   const FUNCTION_RE = new RegExp(
-    `(?<!\\/\\* #__PURE__ \\*\\/ )\\b(${options.functions.join('|')})\\s*\\(`,
+    `(?<!\\/\\* #__PURE__ \\*\\/ )(?:[^a-zA-Z0-9_$]|^)(${options.functions
+      .join('|')
+      .replace('$', '\\$')})\\s*\\(`,
     'g'
   )
   const FUNCTION_RE_SINGLE = new RegExp(
-    `(?<!\\/\\* #__PURE__ \\*\\/ )\\b(${options.functions.join('|')})\\s*\\(`
+    `(?<!\\/\\* #__PURE__ \\*\\/ )(?:[^a-zA-Z0-9_$]|^)(${options.functions
+      .join('|')
+      .replace('$', '\\$')})\\s*\\(`
   )
 
   const filter = createFilter(options.include, options.exclude)

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,13 +15,13 @@ export function PluginPure(options: PureAnnotationsOptions): Plugin {
   const FUNCTION_RE = new RegExp(
     `(?<!\\/\\* #__PURE__ \\*\\/ )(?:[^a-zA-Z0-9_$]|^)(${options.functions
       .join('|')
-      .replace('$', '\\$')})\\s*\\(`,
+      .replaceAll('$', '\\$')})\\s*\\(`,
     'g'
   )
   const FUNCTION_RE_SINGLE = new RegExp(
     `(?<!\\/\\* #__PURE__ \\*\\/ )(?:[^a-zA-Z0-9_$]|^)(${options.functions
       .join('|')
-      .replace('$', '\\$')})\\s*\\(`
+      .replaceAll('$', '\\$')})\\s*\\(`
   )
 
   const filter = createFilter(options.include, options.exclude)


### PR DESCRIPTION
This PR updates the internal regex to allow the full range of function characters.

Valid function character in JavaScript are `[a-zA-Z0-9_$]` while word boundaries (`\b`) in JavaScript’s regex match `[a-zA-Z0-9_]` — poor little `$` is left out in the cold.

In playground mode: https://regexr.com/7jq5l