### PR TITLE
fix: handle immediately nested functions

### DIFF
--- a/playground/src/pure.js
+++ b/playground/src/pure.js
@@ -16,4 +16,10 @@ export const config = $createConfig({
   someConfig: true
 })
 
+// ensures it isn’t over-eager
+defineComponent($createConfig())
+
+// ensures it excludes preceding characters
+console.log('other_defineComponent()')
+
 export const foo = 'hello'

--- a/playground/src/pure.js
+++ b/playground/src/pure.js
@@ -16,10 +16,7 @@ export const config = $createConfig({
   someConfig: true
 })
 
-// ensures it isn’t over-eager
+// ensures regex isn’t over-eager
 defineComponent($createConfig())
-
-// ensures it excludes preceding characters
-console.log('other_defineComponent()')
 
 export const foo = 'hello'

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,13 +13,13 @@ export interface PureAnnotationsOptions {
 
 export function PluginPure(options: PureAnnotationsOptions): Plugin {
   const FUNCTION_RE = new RegExp(
-    `(?<!\\/\\* #__PURE__ \\*\\/ )(?:[^a-zA-Z0-9_$]|^)(${options.functions
+    `(?<!\\/\\* #__PURE__ \\*\\/ )(?<![a-zA-Z0-9_$])(${options.functions
       .join('|')
       .replaceAll('$', '\\$')})\\s*\\(`,
     'g'
   )
   const FUNCTION_RE_SINGLE = new RegExp(
-    `(?<!\\/\\* #__PURE__ \\*\\/ )(?:[^a-zA-Z0-9_$]|^)(${options.functions
+    `(?<!\\/\\* #__PURE__ \\*\\/ )(?<![a-zA-Z0-9_$])(${options.functions
       .join('|')
       .replaceAll('$', '\\$')})\\s*\\(`
   )


### PR DESCRIPTION
The regular expression (I 😔) introduced in `0.2.0` was over-eager and would not match immediately-nested functions like:

```
foo(bar())
```

Where both `foo` and `bar` were part of the function list.

This PR adds a test for this condition which fails without the included fix.