### PR TITLE
chore: replace `latest` ranges with caret ranges

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -8,6 +8,6 @@
   },
   "devDependencies": {
     "rollup-plugin-pure": "latest",
-    "vite": "latest"
+    "vite": "^8.1.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,7 +82,7 @@ importers:
         specifier: link:..
         version: link:..
       vite:
-        specifier: latest
+        specifier: ^8.1.5
         version: 8.1.5(@types/node@24.10.0)(jiti@2.7.0)(yaml@2.9.0)
 
 packages:


### PR DESCRIPTION
`latest` is a curse and can easily drift, or change wildly on lockfile regeneration